### PR TITLE
Update android SDK to v5.2.0

### DIFF
--- a/Android/HUMAN_SDK_Demo/app/build.gradle
+++ b/Android/HUMAN_SDK_Demo/app/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 
     // HUMAN SDK - regular integration
-    implementation 'com.humansecurity:sdk:5.1.0'
+    implementation 'com.humansecurity:sdk:5.2.0'
 
 //    // HUMAN SDK - manual integration
 //    implementation files('libs/HUMAN-release.aar')

--- a/Flutter/HUMAN_Demo/android/app/build.gradle
+++ b/Flutter/HUMAN_Demo/android/app/build.gradle
@@ -56,7 +56,7 @@ flutter {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlin_version}"
 
-    implementation 'com.humansecurity:sdk:5.1.0'
+    implementation 'com.humansecurity:sdk:5.2.0'
 
 //    // HUMAN SDK - manual integration
 //    implementation files('libs/HUMAN-release.aar')

--- a/Ionic/MyApp/android/app/build.gradle
+++ b/Ionic/MyApp/android/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')
 
-    implementation 'com.humansecurity:sdk:5.1.0'
+    implementation 'com.humansecurity:sdk:5.2.0'
 
 //    // HUMAN SDK - manual integration
 //    implementation files('libs/HUMAN-release.aar')

--- a/ReactNative/HUMAN_Demo/android/app/build.gradle
+++ b/ReactNative/HUMAN_Demo/android/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     }
 
     // HUMAN SDK
-    implementation 'com.humansecurity:sdk:5.1.0'
+    implementation 'com.humansecurity:sdk:5.2.0'
 
 //    // HUMAN SDK - manual integration
 //    implementation files('libs/HUMAN-release.aar')


### PR DESCRIPTION
Bump demo apps to android SDK v5.2.0.

**Manual verification required before merge:**
1. Build and run the relevant demo apps
2. Confirm basic SDK flows work
3. Then merge this PR manually

Do **not** auto-merge.