### PR TITLE
Update ios SDK to v5.2.0

### DIFF
--- a/Flutter/HUMAN_Demo/ios/Podfile
+++ b/Flutter/HUMAN_Demo/ios/Podfile
@@ -2,5 +2,5 @@ platform :ios, '13.0'
 use_frameworks!
 
 target 'HumanDemo' do
-	pod 'HUMAN', '5.1.0'
+	pod 'HUMAN', '5.2.0'
 end

--- a/Ionic/MyApp/ios/App/Podfile
+++ b/Ionic/MyApp/ios/App/Podfile
@@ -19,7 +19,7 @@ end
 
 target 'App' do
   capacitor_pods
-  pod 'HUMAN', '5.1.0'
+  pod 'HUMAN', '5.2.0'
   # Add your Pods here
 end
 

--- a/ReactNative/HUMAN_Demo/ios/Podfile
+++ b/ReactNative/HUMAN_Demo/ios/Podfile
@@ -17,7 +17,7 @@ if linkage != nil
 end
 
 target 'HUMAN_Demo' do
-  pod 'HUMAN', '5.1.0'
+  pod 'HUMAN', '5.2.0'
 
   config = use_native_modules!
 

--- a/iOS/HUMAN_SDK_Demo/Podfile
+++ b/iOS/HUMAN_SDK_Demo/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 target 'HUMAN_SDK_Demo' do
   pod 'Alamofire', '~> 5.9.1'
-  pod 'HUMAN', '5.1.0'
+  pod 'HUMAN', '5.2.0'
 end
 
 post_install do |installer|

--- a/visionOS/HumanDemo/HumanDemo.xcodeproj/project.pbxproj
+++ b/visionOS/HumanDemo/HumanDemo.xcodeproj/project.pbxproj
@@ -383,7 +383,7 @@
 			repositoryURL = "https://github.com/PerimeterX/human-security-ios-sdk-spm";
 			requirement = {
 				kind = exactVersion;
-				version = 5.0.0;
+				version = 5.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/visionOS/HumanDemo/HumanDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/visionOS/HumanDemo/HumanDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PerimeterX/human-security-ios-sdk-spm",
       "state" : {
-        "revision" : "efb301152174d6921e2b636df2c43096848f6228",
-        "version" : "5.0.0"
+        "revision" : "28a523372d109de9dc906d63d16c2cc4bb68cf16",
+        "version" : "5.2.0"
       }
     }
   ],


### PR DESCRIPTION
Bump demo apps to ios SDK v5.2.0.

**Manual verification required before merge:**
1. Build and run the relevant demo apps
2. Confirm basic SDK flows work
3. Then merge this PR manually

Do **not** auto-merge.